### PR TITLE
Clear and delete the chain that was created in the tests.

### DIFF
--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -133,4 +133,16 @@ func TestRules(t *testing.T) {
 	if !reflect.DeepEqual(rules, expected) {
 		t.Fatalf("List mismatch: \ngot  %#v \nneed %#v", rules, expected)
 	}
+
+	// Clear the chain that was created.
+	err = ipt.ClearChain("filter", chain)
+	if err != nil {
+		t.Fatalf("Failed to clear test chain: %v", err)
+	}
+
+	// Delete the chain that was created
+	err = ipt.DeleteChain("filter", chain)
+	if err != nil {
+		t.Fatalf("Failed to delete test chain: %v", err)
+	}
 }


### PR DESCRIPTION
In the TestRules test method, there was a chain being created to insert
rules into. Legit. There was no cleaning of this chain after the rules tests
were completed. Not legit. This meant that every time you would run the tests,
it would leave behind a TEST-<rand int> chain. Now, as the last 2 parts of that
method, it will clear the chain and then delete it.