### PR TITLE
Support iptables that don't support locking via flock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
 
 install:
  - go get golang.org/x/tools/cmd/cover
+ - go get github.com/coreos/rkt/pkg/lock
 
 script:
  - ./build-check


### PR DESCRIPTION
This is a modification of @janeczku's patch #8, supporting a mutex via file-locking.

Note that I'm not familiar with the rkt API for mounting file systems, so I didn't implement the cross-host-container mount to share the lock file.

Note that this functionality is *critical* to support RHEL6/CentOS6.

Yes, yes, I know that they're ancient, and we'd never use them unless forced... but we produce software that _uses_ containers, and our _clients_ are the ones that require supporting ancient operating systems. :cry: So the option of "just upgrade the system" doesn't exist for us, unfortunately.