### PR TITLE
Fix locking multiple operations with old iptables

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -44,8 +44,6 @@ type IPTables struct {
 	path     string
 	hasCheck bool
 	hasWait  bool
-
-	fmu *fileLock
 }
 
 func New() (*IPTables, error) {
@@ -63,12 +61,6 @@ func New() (*IPTables, error) {
 		path:     path,
 		hasCheck: checkPresent,
 		hasWait:  waitPresent,
-	}
-	if !waitPresent {
-		ipt.fmu, err = newXtablesFileLock()
-		if err != nil {
-			return nil, err
-		}
 	}
 	return &ipt, nil
 }
@@ -183,7 +175,11 @@ func (ipt *IPTables) runWithOutput(args []string, stdout io.Writer) error {
 	if ipt.hasWait {
 		args = append(args, "--wait")
 	} else {
-		ul, err := ipt.fmu.tryLock()
+		fmu, err := newXtablesFileLock()
+		if err != nil {
+			return err
+		}
+		ul, err := fmu.tryLock()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
If iptables doesn't support the --wait option internal locking is
used.  Unfortunately that locking mishandled multiple chained
operations by closing the lockfile after the first operation and
attempting to re-lock the closed lockfile on subsequent ones.
Fix that by opening the lockfile for each operation.

See https://github.com/coreos/go-iptables/pull/15 for more details.