### PR TITLE
Adding support for ListChains method.

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -139,6 +139,35 @@ func (ipt *IPTables) Delete(table, chain string, rulespec ...string) error {
 // List rules in specified table/chain
 func (ipt *IPTables) List(table, chain string) ([]string, error) {
 	args := []string{"-t", table, "-S", chain}
+	return ipt.executeList(args)
+}
+
+// ListChains returns a slice containing the name of each chain in the specified table.
+func (ipt *IPTables) ListChains(table string) ([]string, error) {
+	args := []string{"-t", table, "-S"}
+
+	// result contains the output of iptables -t $TABLE -S
+	result, err := ipt.executeList(args)
+	if err != nil {
+		return nil, err
+	}
+
+	// Iterating on all the rules to find the -P (default) and -N (New)
+	// Format is the following:
+	// -P OUTPUT ACCEPT
+	// -N Custom
+	var chains []string
+	for _, val := range result {
+		if strings.HasPrefix(val, "-P") || strings.HasPrefix(val, "-N") {
+			chains = append(chains, strings.Fields(val)[1])
+		} else {
+			break
+		}
+	}
+	return chains, nil
+}
+
+func (ipt *IPTables) executeList(args []string) ([]string, error) {
 	var stdout bytes.Buffer
 	if err := ipt.runWithOutput(args, &stdout); err != nil {
 		return nil, err

--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -146,13 +146,13 @@ func (ipt *IPTables) List(table, chain string) ([]string, error) {
 func (ipt *IPTables) ListChains(table string) ([]string, error) {
 	args := []string{"-t", table, "-S"}
 
-	// result contains the output of iptables -t $TABLE -S
 	result, err := ipt.executeList(args)
 	if err != nil {
 		return nil, err
 	}
 
-	// Iterating on all the rules to find the -P (default) and -N (New)
+	// Iterate over rules to find all default (-P) and user-specified (-N) chains.
+	// Chains definition always come before rules.
 	// Format is the following:
 	// -P OUTPUT ACCEPT
 	// -N Custom

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -58,7 +58,7 @@ func randChain(t *testing.T) string {
 }
 
 // simply testing if table/slice contains a specific string value
-func isInTable(list []string, value string) bool {
+func contains(list []string, value string) bool {
 	for _, val := range list {
 		if val == value {
 			return true
@@ -112,7 +112,7 @@ func runChainTests(t *testing.T, ipt *IPTables) {
 	// Saving the list of chains before executing tests
 	originaListChain, err := ipt.ListChains("filter")
 	if err != nil {
-		t.Fatalf("ListChain of Initial failed: %v", err)
+		t.Fatalf("ListChains of Initial failed: %v", err)
 	}
 
 	// chain shouldn't exist, this will create new
@@ -126,7 +126,7 @@ func runChainTests(t *testing.T, ipt *IPTables) {
 	if err != nil {
 		t.Fatalf("ListChain failed: %v", err)
 	}
-	if !isInTable(listChain, chain) {
+	if !contains(listChain, chain) {
 		t.Fatalf("ListChains doesn't contain the new chain %v", chain)
 	}
 
@@ -172,7 +172,7 @@ func runChainTests(t *testing.T, ipt *IPTables) {
 		t.Fatalf("ListChains failed: %v", err)
 	}
 	if !reflect.DeepEqual(originaListChain, listChain) {
-		t.Fatalf("ChainList mismatch: \ngot  %#v \nneed %#v", originaListChain, listChain)
+		t.Fatalf("ListChains mismatch: \ngot  %#v \nneed %#v", originaListChain, listChain)
 	}
 }
 

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -57,7 +57,6 @@ func randChain(t *testing.T) string {
 	return "TEST-" + n.String()
 }
 
-// simply testing if table/slice contains a specific string value
 func contains(list []string, value string) bool {
 	for _, val := range list {
 		if val == value {
@@ -121,10 +120,10 @@ func runChainTests(t *testing.T, ipt *IPTables) {
 		t.Fatalf("ClearChain (of missing) failed: %v", err)
 	}
 
-	// chain should be in ListChain
+	// chain should be in listChain
 	listChain, err := ipt.ListChains("filter")
 	if err != nil {
-		t.Fatalf("ListChain failed: %v", err)
+		t.Fatalf("ListChains failed: %v", err)
 	}
 	if !contains(listChain, chain) {
 		t.Fatalf("ListChains doesn't contain the new chain %v", chain)


### PR DESCRIPTION
This PR introduces a new method to list all the existing chains on a table.

As such, the user can now query ipt.ListChains(TABLE) and get a list of chains.
Out of that list of chains, the user can query The individual Rule list with the existing ipt.List() method.