### PR TITLE
iptables.go: Add support for ListWithCounters method

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -142,6 +142,12 @@ func (ipt *IPTables) List(table, chain string) ([]string, error) {
 	return ipt.executeList(args)
 }
 
+// List rules (with counters) in specified table/chain
+func (ipt *IPTables) ListWithCounters(table, chain string) ([]string, error) {
+	args := []string{"-t", table, "-v", "-S", chain}
+	return ipt.executeList(args)
+}
+
 // ListChains returns a slice containing the name of each chain in the specified table.
 func (ipt *IPTables) ListChains(table string) ([]string, error) {
 	args := []string{"-t", table, "-S"}

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -251,6 +251,22 @@ func runRulesTests(t *testing.T, ipt *IPTables) {
 		t.Fatalf("List mismatch: \ngot  %#v \nneed %#v", rules, expected)
 	}
 
+	rules, err = ipt.ListWithCounters("filter", chain)
+	if err != nil {
+		t.Fatalf("ListWithCounters failed: %v", err)
+	}
+
+	expected = []string{
+		"-N " + chain,
+		"-A " + chain + " -s " + subnet1 + " -d " + address1 + " -c 0 0 -j ACCEPT",
+		"-A " + chain + " -s " + subnet2 + " -d " + address2 + " -c 0 0 -j ACCEPT",
+		"-A " + chain + " -s " + subnet2 + " -d " + address1 + " -c 0 0 -j ACCEPT",
+	}
+
+	if !reflect.DeepEqual(rules, expected) {
+		t.Fatalf("ListWithCounters mismatch: \ngot  %#v \nneed %#v", rules, expected)
+	}
+
 	// Clear the chain that was created.
 	err = ipt.ClearChain("filter", chain)
 	if err != nil {


### PR DESCRIPTION
  This will include the inlined '-c' counters generated by 'iptables -v -S'

It is simpler than the solution presented in https://github.com/coreos/go-iptables/pull/29 as I found it easy enough to unmarshal any lines given by the '-S' rule output.

Please give this a look, and I'm open to suggestions on the method name and such.