### PR TITLE
Add command args to Error struct

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -28,6 +28,7 @@ import (
 // Adds the output of stderr to exec.ExitError
 type Error struct {
 	exec.ExitError
+	cmd exec.Cmd
 	msg string
 }
 
@@ -36,7 +37,7 @@ func (e *Error) ExitStatus() int {
 }
 
 func (e *Error) Error() string {
-	return fmt.Sprintf("exit status %v: %v", e.ExitStatus(), e.msg)
+	return fmt.Sprintf("running %v: exit status %v: %v", e.cmd.Args, e.ExitStatus(), e.msg)
 }
 
 // Protocol to differentiate between IPv4 and IPv6
@@ -248,7 +249,7 @@ func (ipt *IPTables) runWithOutput(args []string, stdout io.Writer) error {
 	}
 
 	if err := cmd.Run(); err != nil {
-		return &Error{*(err.(*exec.ExitError)), stderr.String()}
+		return &Error{*(err.(*exec.ExitError)), cmd, stderr.String()}
 	}
 
 	return nil


### PR DESCRIPTION
This PR is intended to improve the debugging experience for users of this library.

My code makes multiple calls to `Add`, `Insert`, etc., so I either have to wrap each one at the call point with some description of what I was trying to do, or get the lower level to tell me.

Example: before this change:

    exit status 3: iptables v1.4.21: can't initialize iptables table `filter': Permission denied (you must be root)

after

    running [/sbin/iptables -t filter -N TEST-463231 --wait]: exit status 3: iptables v1.4.21: can't initialize iptables table `filter': Permission denied (you must be root)

It could be argued that this change makes the error message more user-hostile, but I don't think it was very friendly previously.