### PR TITLE
Add support for iptables in nftables mode.

### DIFF
--- a/test
+++ b/test
@@ -45,11 +45,14 @@ split=(${TEST// / })
 TEST=${split[@]/#/${REPO_PATH}/}
 
 echo "Running tests..."
-go test -i ${TEST}
+bin=$(mktemp)
+
+go test -c -o ${bin} ${COVER} -i ${TEST}
 if [[ -z "$SUDO_PERMITTED" ]]; then
     echo "Test aborted for safety reasons. Please set the SUDO_PERMITTED variable."
     exit 1
 fi
 
-sudo -E bash -c "PATH=\$GOROOT/bin:\$PATH go test ${COVER} $@ ${TEST}"
+sudo -E bash -c "${bin} $@ ${TEST}"
 echo "Success"
+rm "${bin}"


### PR DESCRIPTION
Iptables also has the ability to work in nftables mode, where it is supposed to act like iptables but use the nftables subsystem. Unfortunately, it isn't exactly the same.

The biggest difference is that counter output is iptables-save style, rather than with "-c N N".

Also, improve some tests.

Fixes: #49 