### PR TITLE
iptables in nft mode now prints an error for non-existent chains

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -348,18 +348,6 @@ func (ipt *IPTables) executeList(args []string) ([]string, error) {
 		rules = rules[:len(rules)-1]
 	}
 
-	// nftables mode doesn't return an error code when listing a non-existent
-	// chain. Patch that up.
-	if len(rules) == 0 && ipt.mode == "nf_tables" {
-		v := 1
-		return nil, &Error{
-			cmd:        exec.Cmd{Args: args},
-			msg:        fmt.Sprintf("%s: No chain/target/match by that name.\n", getIptablesCommand(ipt.proto)),
-			proto:      ipt.proto,
-			exitStatus: &v,
-		}
-	}
-
 	for i, rule := range rules {
 		rules[i] = filterRuleOutput(rule)
 	}


### PR DESCRIPTION
This reverts part of "Add support for iptables in nftables mode.",
which was added to work around some temporary issues in unreleased
iptables versions that have since been corrected upstream.

This specific issue was fixed in:

03572549df349455fcade80dfab0b28904975330
xtables: Print error when listing non-existent chains

@squeed @mheon @baude