### PR TITLE
Added StructuredStats method to returned structured stat data

### DIFF
--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -307,6 +307,23 @@ func runRulesTests(t *testing.T, ipt *IPTables) {
 		t.Fatalf("Stats mismatch: \ngot  %#v \nneed %#v", stats, expectedStats)
 	}
 
+	structStats, err := ipt.StructuredStats("filter", chain)
+	if err != nil {
+		t.Fatalf("StructuredStats failed: %v", err)
+	}
+
+	expectedStructStats := []Stat{
+		{"0", "0", "ACCEPT", "all", opt, "*", "*", subnet1, address1, ""},
+		{"0", "0", "ACCEPT", "all", opt, "*", "*", subnet2, address2, ""},
+		{"0", "0", "ACCEPT", "all", opt, "*", "*", subnet2, address1, ""},
+		{"0", "0", "ACCEPT", "all", opt, "*", "*", address1, subnet2, ""},
+	}
+
+	if !reflect.DeepEqual(structStats, expectedStructStats) {
+		t.Fatalf("StructuredStats mismatch: \ngot  %#v \nneed %#v",
+			structStats, expectedStructStats)
+	}
+
 	// Clear the chain that was created.
 	err = ipt.ClearChain("filter", chain)
 	if err != nil {


### PR DESCRIPTION
This additional method maintains the currently available `Stats` method while adding a `StructuredStats` method, which returns structured data instead of a slice of string slices with statistics. This allows the caller to use a defined data structure for accessing fields in a specific statistic.

Although a caller could peer into the existing `Stats` method to determine what each field is, providing this abstraction allows for more portability/usability.