### PR TITLE
Add netns support

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -62,6 +62,7 @@ const (
 )
 
 type IPTables struct {
+	netNs          string
 	path           string
 	proto          Protocol
 	hasCheck       bool
@@ -75,13 +76,13 @@ type IPTables struct {
 
 // New creates a new IPTables.
 // For backwards compatibility, this always uses IPv4, i.e. "iptables".
-func New() (*IPTables, error) {
-	return NewWithProtocol(ProtocolIPv4)
+func New(ns string) (*IPTables, error) {
+	return NewWithProtocol(ProtocolIPv4, ns)
 }
 
 // New creates a new IPTables for the given proto.
 // The proto will determine which command is used, either "iptables" or "ip6tables".
-func NewWithProtocol(proto Protocol) (*IPTables, error) {
+func NewWithProtocol(proto Protocol, netNs string) (*IPTables, error) {
 	path, err := exec.LookPath(getIptablesCommand(proto))
 	if err != nil {
 		return nil, err
@@ -101,6 +102,7 @@ func NewWithProtocol(proto Protocol) (*IPTables, error) {
 		v2:             v2,
 		v3:             v3,
 		mode:           mode,
+		netNs:          netNs,
 	}
 	return &ipt, nil
 }
@@ -361,6 +363,7 @@ func (ipt *IPTables) run(args ...string) error {
 // runWithOutput runs an iptables command with the given arguments,
 // writing any stdout output to the given writer
 func (ipt *IPTables) runWithOutput(args []string, stdout io.Writer) error {
+	var err error
 	args = append([]string{ipt.path}, args...)
 	if ipt.hasWait {
 		args = append(args, "--wait")
@@ -376,9 +379,19 @@ func (ipt *IPTables) runWithOutput(args []string, stdout io.Writer) error {
 		defer ul.Unlock()
 	}
 
+	path := ipt.path
+	if ipt.netNs != "" {
+		path, err = exec.LookPath("ip")
+		if err != nil {
+			return err
+		}
+		prefix := []string{"ip", "netns", "exec", ipt.netNs}
+		args = append(prefix, args...)
+	}
+
 	var stderr bytes.Buffer
 	cmd := exec.Cmd{
-		Path:   ipt.path,
+		Path:   path,
 		Args:   args,
 		Stdout: stdout,
 		Stderr: &stderr,

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestProto(t *testing.T) {
-	ipt, err := New()
+	ipt, err := New("")
 	if err != nil {
 		t.Fatalf("New failed: %v", err)
 	}
@@ -32,7 +32,7 @@ func TestProto(t *testing.T) {
 		t.Fatalf("Expected default protocol IPv4, got %v", ipt.Proto())
 	}
 
-	ip4t, err := NewWithProtocol(ProtocolIPv4)
+	ip4t, err := NewWithProtocol(ProtocolIPv4, "")
 	if err != nil {
 		t.Fatalf("NewWithProtocol(ProtocolIPv4) failed: %v", err)
 	}
@@ -40,7 +40,7 @@ func TestProto(t *testing.T) {
 		t.Fatalf("Expected protocol IPv4, got %v", ip4t.Proto())
 	}
 
-	ip6t, err := NewWithProtocol(ProtocolIPv6)
+	ip6t, err := NewWithProtocol(ProtocolIPv6, "")
 	if err != nil {
 		t.Fatalf("NewWithProtocol(ProtocolIPv6) failed: %v", err)
 	}
@@ -71,11 +71,11 @@ func contains(list []string, value string) bool {
 // features enabled & disabled, to test compatibility.
 // We used to test noWait as well, but that was removed as of iptables v1.6.0
 func mustTestableIptables() []*IPTables {
-	ipt, err := New()
+	ipt, err := New("")
 	if err != nil {
 		panic(fmt.Sprintf("New failed: %v", err))
 	}
-	ip6t, err := NewWithProtocol(ProtocolIPv6)
+	ip6t, err := NewWithProtocol(ProtocolIPv6, "")
 	if err != nil {
 		panic(fmt.Sprintf("NewWithProtocol(ProtocolIPv6) failed: %v", err))
 	}
@@ -322,7 +322,7 @@ func runRulesTests(t *testing.T, ipt *IPTables) {
 
 // TestError checks that we're OK when iptables fails to execute
 func TestError(t *testing.T) {
-	ipt, err := New()
+	ipt, err := New("")
 	if err != nil {
 		t.Fatalf("failed to init: %v", err)
 	}
@@ -357,7 +357,7 @@ func TestError(t *testing.T) {
 }
 
 func TestIsNotExist(t *testing.T) {
-	ipt, err := New()
+	ipt, err := New("")
 	if err != nil {
 		t.Fatalf("failed to init: %v", err)
 	}
@@ -419,7 +419,7 @@ func TestIsNotExist(t *testing.T) {
 }
 
 func TestIsNotExistForIPv6(t *testing.T) {
-	ipt, err := NewWithProtocol(ProtocolIPv6)
+	ipt, err := NewWithProtocol(ProtocolIPv6, "")
 	if err != nil {
 		t.Fatalf("failed to init: %v", err)
 	}


### PR DESCRIPTION
If a network namespace is passed to the New* methods, then the "ip" command is prefixed and apprended the iptables command as argument to "ip netns *id* exec ..."