### PR TITLE
close xtables lock on errors before returning

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -437,6 +437,7 @@ func (ipt *IPTables) runWithOutput(args []string, stdout io.Writer) error {
 		}
 		ul, err := fmu.tryLock()
 		if err != nil {
+			syscall.Close(fmu.fd)
 			return err
 		}
 		defer ul.Unlock()


### PR DESCRIPTION
In relation to: https://github.com/coreos/go-iptables/issues/61 if the lock file is successfully opened, but there was an error acquiring a lock, runWithOutput exits without closing the file.  This patch  tries to close the file before returning.