### PR TITLE
Enable environment variable expansion

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"os"
 )
 
 // Adds the output of stderr to exec.ExitError
@@ -432,6 +433,12 @@ func (ipt *IPTables) runWithOutput(args []string, stdout io.Writer) error {
 	}
 
 	var stderr bytes.Buffer
+
+	//expand environment variables
+	for index, element := range args {
+		args[index] = os.ExpandEnv(element)
+	}
+
 	cmd := exec.Cmd{
 		Path:   ipt.path,
 		Args:   args,


### PR DESCRIPTION



now this is the command:
`/usr/sbin/iptables -t filter -A OUTPUT -o $CNI_IFNAME -p icmp -d 0/0 --icmp-type 8 -j ACCEPT --wait`

CNI_IFNAME is listed as interface in the iptables output
```
[@ firewallnetns]#ip netns exec testing iptables -L -vn
Chain INPUT (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination
    0     0 ACCEPT     icmp --  $CNI_IFNAME *       0.0.0.0/0            0.0.0.0/0            icmptype 8
    0     0 ACCEPT     icmp --  $CNI_IFNAME *       0.0.0.0/0            0.0.0.0/0            icmptype 0
    0     0 ACCEPT     all  --  *      *       192.168.122.159      0.0.0.0/0

Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination

Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
 pkts bytes target     prot opt in     out     source               destination
    0     0 ACCEPT     icmp --  *      $CNI_IFNAME  0.0.0.0/0            0.0.0.0/0            icmptype 0
    0     0 ACCEPT     icmp --  *      $CNI_IFNAME  0.0.0.0/0            0.0.0.0/0            icmptype 8
```

should be this:
`/usr/sbin/iptables -t filter -A OUTPUT -o eth0 -p icmp -d 0/0 --icmp-type 8 -j ACCEPT --wait`

