### PR TITLE
Check and return an error when iptables version parsing fails

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -101,7 +101,13 @@ func NewWithProtocol(proto Protocol) (*IPTables, error) {
 		return nil, err
 	}
 	vstring, err := getIptablesVersionString(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not get iptables version: %v", err)
+	}
 	v1, v2, v3, mode, err := extractIptablesVersion(vstring)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract iptables version from [%s]: %v", vstring, err)
+	}
 
 	checkPresent, waitPresent, randomFullyPresent := getIptablesCommandSupport(v1, v2, v3)
 


### PR DESCRIPTION
The version retrieval and parsing functions return an error which is ignored.

If the parsing fails, the version may be empty and the library may think that `--wait` flag is not supported. 
If that flag is not supported, the library will try to lock `/var/run/xtables.lock` and only after that invoke `iptables`, which in turn will find the file locked and return an error.

This patch returns the version parsing error to the caller.

I tried to reproduce the failing part by forcing `hasWait` to false locally, not sure how can the version parsing fail but it what (I suspect) happened on kubevirt CI. More details in the issue: https://github.com/kubevirt/kubevirt/issues/2660