### PR TITLE
iptables IsNotExist robustness

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -49,8 +49,8 @@ func (e *Error) Error() string {
 // IsNotExist returns true if the error is due to the chain or rule not existing
 func (e *Error) IsNotExist() bool {
 	return e.ExitStatus() == 1 &&
-		(e.msg == fmt.Sprintf("%s: Bad rule (does a matching rule exist in that chain?).\n", getIptablesCommand(e.proto)) ||
-			e.msg == fmt.Sprintf("%s: No chain/target/match by that name.\n", getIptablesCommand(e.proto)))
+		strings.Contains(e.msg, fmt.Sprintf("%s: Bad rule (does a matching rule exist in that chain?).\n", getIptablesCommand(e.proto))) ||
+		strings.Contains(e.msg, fmt.Sprintf("%s: No chain/target/match by that name.\n", getIptablesCommand(e.proto)))
 }
 
 // Protocol to differentiate between IPv4 and IPv6

--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -452,6 +452,13 @@ func TestIsNotExist(t *testing.T) {
 	if !e.IsNotExist() {
 		t.Fatal("IsNotExist returned false, expected true")
 	}
+
+	// iptables may add more logs to the errors msgs
+	e.msg = "Another app is currently holding the xtables lock; waiting (1s) for it to exit..." + e.msg
+	if !e.IsNotExist() {
+		t.Fatal("IsNotExist returned false, expected true")
+	}
+
 }
 
 func TestIsNotExistForIPv6(t *testing.T) {
@@ -511,6 +518,12 @@ func TestIsNotExistForIPv6(t *testing.T) {
 		t.Fatalf("Got wrong error type, expected iptables.Error, got %T", err)
 	}
 
+	if !e.IsNotExist() {
+		t.Fatal("IsNotExist returned false, expected true")
+	}
+
+	// iptables may add more logs to the errors msgs
+	e.msg = "Another app is currently holding the xtables lock; waiting (1s) for it to exit..." + e.msg
 	if !e.IsNotExist() {
 		t.Fatal("IsNotExist returned false, expected true")
 	}


### PR DESCRIPTION
iptables appends sometimes more logs to the error message.
The function err.IsNotExist fails when it does't match the exact string.
We make the function more robust matching for the substring inside the error message.

xref: https://github.com/containernetworking/plugins/pull/421#issuecomment-565005419