### PR TITLE
fix comparison precedence order in the IsNotExist() method

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -48,9 +48,13 @@ func (e *Error) Error() string {
 
 // IsNotExist returns true if the error is due to the chain or rule not existing
 func (e *Error) IsNotExist() bool {
-	return e.ExitStatus() == 1 &&
-		strings.Contains(e.msg, fmt.Sprintf("%s: Bad rule (does a matching rule exist in that chain?).\n", getIptablesCommand(e.proto))) ||
-		strings.Contains(e.msg, fmt.Sprintf("%s: No chain/target/match by that name.\n", getIptablesCommand(e.proto)))
+	if e.ExitStatus() != 1 {
+		return false
+	}
+	cmdIptables := getIptablesCommand(e.proto)
+	msgNoRuleExist := fmt.Sprintf("%s: Bad rule (does a matching rule exist in that chain?).\n", cmdIptables)
+	msgNoChainExist := fmt.Sprintf("%s: No chain/target/match by that name.\n", cmdIptables)
+	return strings.Contains(e.msg, msgNoRuleExist) || strings.Contains(e.msg, msgNoChainExist)
 }
 
 // Protocol to differentiate between IPv4 and IPv6


### PR DESCRIPTION
The comparison done in the IsNotExist method is missing
the parenthesis aggregating the logical or statements,
thus the expression evaluation is not working as
expected.

Signed-off-by: Antonio Ojea <antonio.ojea.garcia@gmail.com>