### PR TITLE
Fix IsNotExist for ip6tables in nft mode

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -31,7 +31,6 @@ type Error struct {
 	exec.ExitError
 	cmd        exec.Cmd
 	msg        string
-	proto      Protocol
 	exitStatus *int //for overriding
 }
 
@@ -51,9 +50,8 @@ func (e *Error) IsNotExist() bool {
 	if e.ExitStatus() != 1 {
 		return false
 	}
-	cmdIptables := getIptablesCommand(e.proto)
-	msgNoRuleExist := fmt.Sprintf("%s: Bad rule (does a matching rule exist in that chain?).\n", cmdIptables)
-	msgNoChainExist := fmt.Sprintf("%s: No chain/target/match by that name.\n", cmdIptables)
+	msgNoRuleExist := "Bad rule (does a matching rule exist in that chain?).\n"
+	msgNoChainExist := "No chain/target/match by that name.\n"
 	return strings.Contains(e.msg, msgNoRuleExist) || strings.Contains(e.msg, msgNoChainExist)
 }
 
@@ -452,7 +450,7 @@ func (ipt *IPTables) runWithOutput(args []string, stdout io.Writer) error {
 	if err := cmd.Run(); err != nil {
 		switch e := err.(type) {
 		case *exec.ExitError:
-			return &Error{*e, cmd, stderr.String(), ipt.proto, nil}
+			return &Error{*e, cmd, stderr.String(), nil}
 		default:
 			return err
 		}


### PR DESCRIPTION
Don't include the command name when comparing the error messages.
"ip6tables" in nft mode uses "iptables" in it's error messages.

E.g.:
in nft mode:
```
ip6tables  -D POSTROUTING -s 1100:200::5/24 -j DROP
iptables: Bad rule (does a matching rule exist in that chain?).
```

same command in legacy mode:
```
ip6tables -t nat -D POSTROUTING -s 1100:200::5/24 -j DROP
ip6tables: Bad rule (does a matching rule exist in that chain?).
```

Note: This is a partial revert of 59918691198246af297de618214b098f78c98804

Signed-off-by: Ralf Haferkamp <rhafer@suse.com>