### PR TITLE
workflows: add Go 1.20, update golangci-lint, switch to setup-go v4

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
     - name: Check out repository

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x, 1.18.x, 1.19.x]
+        go-version: [1.16.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x]
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,5 +33,5 @@ jobs:
     - name: Run linter
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.48.0
+        version: v1.51.1
         args: -E=gofmt --timeout=30m0s


### PR DESCRIPTION
Cache dependencies and build outputs by default.