### PR TITLE
iptables_test: fix ListWithCounters mismatch on newer kernels to fix CI

### DIFF
--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -131,7 +131,7 @@ func runChainTests(t *testing.T, ipt *IPTables) {
 	chain := randChain(t)
 
 	// Saving the list of chains before executing tests
-	originaListChain, err := ipt.ListChains("filter")
+	originalListChain, err := ipt.ListChains("filter")
 	if err != nil {
 		t.Fatalf("ListChains of Initial failed: %v", err)
 	}
@@ -204,8 +204,8 @@ func runChainTests(t *testing.T, ipt *IPTables) {
 	if err != nil {
 		t.Fatalf("ListChains failed: %v", err)
 	}
-	if !reflect.DeepEqual(originaListChain, listChain) {
-		t.Fatalf("ListChains mismatch: \ngot  %#v \nneed %#v", originaListChain, listChain)
+	if !reflect.DeepEqual(originalListChain, listChain) {
+		t.Fatalf("ListChains mismatch: \ngot  %#v \nneed %#v", originalListChain, listChain)
 	}
 
 	// ChainExists must not find it anymore

--- a/test
+++ b/test
@@ -47,7 +47,7 @@ TEST=${split[@]/#/${REPO_PATH}/}
 echo "Running tests..."
 bin=$(mktemp)
 
-go test -c -o ${bin} ${COVER} -i ${TEST}
+go test -c -o ${bin} ${COVER} ${TEST}
 if [[ -z "$SUDO_PERMITTED" ]]; then
     echo "Test aborted for safety reasons. Please set the SUDO_PERMITTED variable."
     exit 1


### PR DESCRIPTION
Current nf_tables apparently uses the `-c 0 0 -j ACCEPT` ordering for table entries.  Rather than trying to guess which order we'll get, accept either one.