### PR TITLE
Skip warning about rules in legacy iptables.

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -316,6 +316,11 @@ func (ipt *IPTables) Stats(table, chain string) ([][]string, error) {
 
 	ipv6 := ipt.proto == ProtocolIPv6
 
+	// Skip the warning if exist
+	if strings.HasPrefix(lines[0], "#") {
+		lines = lines[1:]
+	}
+
 	rows := [][]string{}
 	for i, line := range lines {
 		// Skip over chain name and field header


### PR DESCRIPTION
After iptables support nft backend, it will emit the following warning if there are rules in the legacy iptables. "# Warning: iptables-legacy tables present, use iptables-legacy to see them". This cause the header skipping to fail in the following loop.