### PR TITLE
Add another pattern to IsNotExist

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -52,7 +52,8 @@ func (e *Error) IsNotExist() bool {
 	}
 	msgNoRuleExist := "Bad rule (does a matching rule exist in that chain?).\n"
 	msgNoChainExist := "No chain/target/match by that name.\n"
-	return strings.Contains(e.msg, msgNoRuleExist) || strings.Contains(e.msg, msgNoChainExist)
+	msgENOENT := "No such file or directory"
+	return strings.Contains(e.msg, msgNoRuleExist) || strings.Contains(e.msg, msgNoChainExist) || strings.Contains(e.msg, msgENOENT)
 }
 
 // Protocol to differentiate between IPv4 and IPv6


### PR DESCRIPTION
With iptables-nft, this can happen:

    process 1                       process 2
    ask kernel if chain X exists    ask kernel if chain X exists
      --> yes                         --> yes
                                    ask kernel to delete chain X
                                      --> OK
    ask kernel to delete chain X
      --> ENOENT

You only get the normal "chain doesn't exist" error message if the initial check fails; if another process deletes the chain after that, then it outputs the raw kernel error. (This can happen in the containernetworking/plugins tests.)

So make IsNotExist recognize "No such file or directory".

cc @squeed