### PR TITLE
Add yet another pattern to IsNotExist

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -45,15 +45,21 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("running %v: exit status %v: %v", e.cmd.Args, e.ExitStatus(), e.msg)
 }
 
+var isNotExistPatterns = []string{
+	"Bad rule (does a matching rule exist in that chain?).\n",
+	"No chain/target/match by that name.\n",
+	"No such file or directory",
+	"does not exist",
+}
+
 // IsNotExist returns true if the error is due to the chain or rule not existing
 func (e *Error) IsNotExist() bool {
-	if e.ExitStatus() != 1 {
-		return false
+	for _, str := range isNotExistPatterns {
+		if strings.Contains(e.msg, str) {
+			return true
+		}
 	}
-	msgNoRuleExist := "Bad rule (does a matching rule exist in that chain?).\n"
-	msgNoChainExist := "No chain/target/match by that name.\n"
-	msgENOENT := "No such file or directory"
-	return strings.Contains(e.msg, msgNoRuleExist) || strings.Contains(e.msg, msgNoChainExist) || strings.Contains(e.msg, msgENOENT)
+	return false
 }
 
 // Protocol to differentiate between IPv4 and IPv6


### PR DESCRIPTION
https://github.com/coreos/go-iptables/pull/107 handled iptables-legacy but not iptables-nft.

Seen in https://github.com/containernetworking/plugins/actions/runs/5715835655/job/15486163430?pr=935:

```
  [FAILED] Unexpected error:
      <*errors.errorString | 0xc0003bdb20>: 
      running [/usr/sbin/iptables -t nat -D POSTROUTING -s 10.1.2.2 -j CNI-43a5a67926c1a665ff4c21b7 -m comment --comment name: "testConfig" id: "dummy-0" --wait]: exit status 2: iptables v1.8.7 (nf_tables): Chain 'CNI-43a5a67926c1a665ff4c21b7' does not exist
```