### PR TITLE
Go 1.21.x in tests matrix

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x]
+        go-version: [1.16.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x, 1.21.x]
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x


### PR DESCRIPTION
This PR adds Go 1.21 to the test matrix.

Tests running on my fork: https://github.com/cheina97/go-iptables/pull/2