### PR TITLE
feat: add DeleteById function

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -241,6 +241,24 @@ func (ipt *IPTables) DeleteIfExists(table, chain string, rulespec ...string) err
 	return err
 }
 
+// DeleteById deletes the rule with the specified ID in the given table and chain.
+func (ipt *IPTables) DeleteById(table, chain string, id int) (string, error) {
+	rules, err := ipt.List(table, chain)
+	if err != nil {
+		return "", err
+	}
+
+	for _, rule := range rules {
+		args := []string{"-t", table, "-D", chain, strconv.Itoa(id)}
+		_, err := ipt.executeList(args)
+		if err != nil {
+			return "", fmt.Errorf("rule %s with ID %d not found: %v", rule, id, err)
+		}
+	}
+
+	return "Rule deleted successfully", nil
+}
+
 // List rules in specified table/chain
 func (ipt *IPTables) ListById(table, chain string, id int) (string, error) {
 	args := []string{"-t", table, "-S", chain, strconv.Itoa(id)}


### PR DESCRIPTION
Fix: #97 
feat: users now have the option to delete a specific rule.

Rule numbers can be found by using the following command:
```sudo iptables -t nat -L PREROUTING -n --line-number```


Example usage:
```
        table := "nat"
	chain := "PREROUTING"
	ruleIDToDelete := 2

	// Use the DeleteById function to delete the rule.
	result, err := iptables.DeleteById(table, chain, ruleIDToDelete)
	if err != nil {
		fmt.Printf("Error: %v\n", err)
	} else {
		fmt.Println(result)
	}