### PR TITLE
Fix: iptables stats tests for iptables >= 1.8.9

### DIFF
--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -372,15 +372,25 @@ func runRulesTests(t *testing.T, ipt *IPTables) {
 	}
 
 	opt := "--"
-	if ipt.proto == ProtocolIPv6 {
+	prot := "0"
+	if ipt.proto == ProtocolIPv6 &&
+		ipt.v1 == 1 && ipt.v2 <= 8 && ipt.v3 < 9 {
+		// this is fixed in iptables 1.8.9 via iptables/6e41c2d874
 		opt = "  "
+		// this is fixed in iptables 1.8.9 via iptables/da8ecc62dd
+		prot = "all"
+	}
+	if ipt.proto == ProtocolIPv4 &&
+		ipt.v1 == 1 && ipt.v2 <= 8 && ipt.v3 < 9 {
+		// this is fixed in iptables 1.8.9 via iptables/da8ecc62dd
+		prot = "all"
 	}
 
 	expectedStats := [][]string{
-		{"0", "0", "ACCEPT", "all", opt, "*", "*", subnet1, address1, ""},
-		{"0", "0", "ACCEPT", "all", opt, "*", "*", subnet2, address2, ""},
-		{"0", "0", "ACCEPT", "all", opt, "*", "*", subnet2, address1, ""},
-		{"0", "0", "ACCEPT", "all", opt, "*", "*", address1, subnet2, ""},
+		{"0", "0", "ACCEPT", prot, opt, "*", "*", subnet1, address1, ""},
+		{"0", "0", "ACCEPT", prot, opt, "*", "*", subnet2, address2, ""},
+		{"0", "0", "ACCEPT", prot, opt, "*", "*", subnet2, address1, ""},
+		{"0", "0", "ACCEPT", prot, opt, "*", "*", address1, subnet2, ""},
 	}
 
 	if !reflect.DeepEqual(stats, expectedStats) {
@@ -400,10 +410,10 @@ func runRulesTests(t *testing.T, ipt *IPTables) {
 	_, subnet2CIDR, _ := net.ParseCIDR(subnet2)
 
 	expectedStructStats := []Stat{
-		{0, 0, "ACCEPT", "all", opt, "*", "*", subnet1CIDR, address1CIDR, ""},
-		{0, 0, "ACCEPT", "all", opt, "*", "*", subnet2CIDR, address2CIDR, ""},
-		{0, 0, "ACCEPT", "all", opt, "*", "*", subnet2CIDR, address1CIDR, ""},
-		{0, 0, "ACCEPT", "all", opt, "*", "*", address1CIDR, subnet2CIDR, ""},
+		{0, 0, "ACCEPT", prot, opt, "*", "*", subnet1CIDR, address1CIDR, ""},
+		{0, 0, "ACCEPT", prot, opt, "*", "*", subnet2CIDR, address2CIDR, ""},
+		{0, 0, "ACCEPT", prot, opt, "*", "*", subnet2CIDR, address1CIDR, ""},
+		{0, 0, "ACCEPT", prot, opt, "*", "*", address1CIDR, subnet2CIDR, ""},
 	}
 
 	if !reflect.DeepEqual(structStats, expectedStructStats) {


### PR DESCRIPTION
IPTables fixed a couple long-standing discrepancies in ipv4/ipv6's -L output.
Unfortunately these fixes break out tests and potentially, stat parsing.
    
In detail, the following were fixed in 1.8.9 and later:
* ip6tables' opt column outputting spaces instead of dashes
* ip6tables' prot column not resolving "all" to "0", even with numeric mode activated.
* iptables' prot column not resolving "all" to "0", even with numeric mode activated.

 Handle them, so that tests keep working post 1.8.9.
