### PR TITLE
Feat: Support overriding binaries' path

### DIFF
--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -70,6 +70,54 @@ func TestTimeout(t *testing.T) {
 
 }
 
+// force usage of -legacy or -nft commands and check that they're detected correctly
+func TestLegacyDetection(t *testing.T) {
+	testCases := []struct {
+		in   string
+		mode string
+		err  bool
+	}{
+		{
+			"iptables-legacy",
+			"legacy",
+			false,
+		},
+		{
+			"ip6tables-legacy",
+			"legacy",
+			false,
+		},
+		{
+			"iptables-nft",
+			"nf_tables",
+			false,
+		},
+		{
+			"ip6tables-nft",
+			"nf_tables",
+			false,
+		},
+	}
+
+	for i, tt := range testCases {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			ipt, err := New(Path(tt.in))
+			if err == nil && tt.err {
+				t.Fatal("expected err, got none")
+			} else if err != nil && !tt.err {
+				t.Fatalf("unexpected err %s", err)
+			}
+
+			if !strings.Contains(ipt.path, tt.in) {
+				t.Fatalf("Expected path %s in %s", tt.in, ipt.path)
+			}
+			if ipt.mode != tt.mode {
+				t.Fatalf("Expected %s iptables, but got %s", tt.mode, ipt.mode)
+			}
+		})
+	}
+}
+
 func randChain(t *testing.T) string {
 	n, err := rand.Int(rand.Reader, big.NewInt(1000000))
 	if err != nil {


### PR DESCRIPTION
Allow overriding binaries path, via a new function, named Path(string). This works similarily to other options such as Timeout() and configures IPTables's scruct.

This is particularly useful in sudo-confined environments or any wrapping scenarios.

while there, add a set of tests that force iptables into legacy or nft versions and then compare it with the mode parsed through executing the utility.