### PR TITLE
Fix the 1.8.9 version check

### DIFF
--- a/iptables/iptables_test.go
+++ b/iptables/iptables_test.go
@@ -422,14 +422,14 @@ func runRulesTests(t *testing.T, ipt *IPTables) {
 	opt := "--"
 	prot := "0"
 	if ipt.proto == ProtocolIPv6 &&
-		ipt.v1 == 1 && ipt.v2 <= 8 && ipt.v3 < 9 {
+		ipt.v1 == 1 && (ipt.v2 < 8 || (ipt.v2 == 8 && ipt.v3 < 9)) {
 		// this is fixed in iptables 1.8.9 via iptables/6e41c2d874
 		opt = "  "
 		// this is fixed in iptables 1.8.9 via iptables/da8ecc62dd
 		prot = "all"
 	}
 	if ipt.proto == ProtocolIPv4 &&
-		ipt.v1 == 1 && ipt.v2 <= 8 && ipt.v3 < 9 {
+		ipt.v1 == 1 && (ipt.v2 < 8 || (ipt.v2 == 8 && ipt.v3 < 9)) {
 		// this is fixed in iptables 1.8.9 via iptables/da8ecc62dd
 		prot = "all"
 	}


### PR DESCRIPTION
The current version check fails for any version where the patch version is 9 or greater. 1.4.21 is still in use e.g. on RHEL 7:

    ipt.v1 == 1 && ipt.v2 <= 8 && ipt.v3 < 9

fails there because 21 >= 9.

To handle this, the check needs to distinguish ipt.v2 < 8 (v3 is not significant then) and ipt.v2 == 8 (v3 needs to be compared).