### PR TITLE
Add "build" script back

### DIFF
--- a/build
+++ b/build
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+go build ./...


### PR DESCRIPTION
Apparently the CI templates require it to exist.